### PR TITLE
Added GeNN and mlGeNN to software

### DIFF
--- a/content/english/neuromorphic-computing/software/snn-frameworks/genn/index.md
+++ b/content/english/neuromorphic-computing/software/snn-frameworks/genn/index.md
@@ -1,8 +1,8 @@
 ---
 title: "GeNN"
 type: neuromorphic-software
-description: Simulator for SNN models focusing on dynamics, size, structure of neural systems, not on individual neuron morphology.
-logo: nest.png
+description: Simulator for SNN models focusing on networks, not on individual neuron morphology. Optimised for accelerated simulations on computational backends including NVIDIA GPUs.
+logo: 
 website: https://genn-team.github.io/
 dependencies: 
 field_of_application: Neuroscience, Machine learning
@@ -20,7 +20,9 @@ draft: false
 
 ## Overview
 **GeNN** is a software package to accelerate Spiking Neural Network simulations 
-on hardware including NVIDIA GPUs using code generation. Networks are described using a simple Python API and the models and snippets used to describe the behaviour of the neurons and synapses which make up the networks are easily customised using strings containing a C-like language called GeNNCode. GeNN provides extensive documentation and tutorials.
+on hardware including NVIDIA GPUs. GeNN uses code generation to ``computational backends'' to build simulations. The main backends are curerently C++/CUDA for NVIDIA GPUs or C++ for CPU-only mode. GenNN is available on Linux, Windows, MacOS.
+
+Networks are described using a simple Python API and built out of model components that can be fully customized. The behaviour of neurons, synapses, plasticity mechanisms, initialisation methods and connectivity construction are defined using Python strings containing a C-like language called GeNNCode. Users can fully customise these components. GeNN provides extensive documentation and tutorials.
 
 GeNN focusses on flexibility and performance on a single GPU, providing unique features for offloading initialisation to the GPU and even generating connectivity on the fly, allowing very large models (millions of neurons and billions of synapses to be simulated on a single GPU.
 Because of this flexibility, GeNN has been used across a wide range of applications from simulating large-scale models of cortex to training recurrent SNNs using gradient-based learning for machine learning tasks.

--- a/content/english/neuromorphic-computing/software/snn-frameworks/genn/index.md
+++ b/content/english/neuromorphic-computing/software/snn-frameworks/genn/index.md
@@ -5,7 +5,7 @@ description: Simulator for SNN models focusing on dynamics, size, structure of n
 logo: nest.png
 website: https://genn-team.github.io/
 dependencies: 
-field_of_application: Neuroscience
+field_of_application: Neuroscience, Machine learning
 source_code: https://github.com/genn-team/genn
 stars_widget_url: https://img.shields.io/github/stars/genn-team/genn.svg?style=social
 stars: 233

--- a/content/english/neuromorphic-computing/software/snn-frameworks/genn/index.md
+++ b/content/english/neuromorphic-computing/software/snn-frameworks/genn/index.md
@@ -20,7 +20,7 @@ draft: false
 
 ## Overview
 **GeNN** is a software package to accelerate Spiking Neural Network simulations 
-on hardware including NVIDIA GPUs. GeNN uses code generation to ``computational backends'' to build simulations. The main backends are curerently C++/CUDA for NVIDIA GPUs or C++ for CPU-only mode. GenNN is available on Linux, Windows, MacOS.
+on hardware including NVIDIA GPUs. GeNN uses code generation with various 'backends' to run simulations. The main backends are currently C++/CUDA for NVIDIA GPUs or C++ for CPU-only mode. GeNN is available on Linux, Windows, MacOS.
 
 Networks are described using a simple Python API and built out of model components that can be fully customized. The behaviour of neurons, synapses, plasticity mechanisms, initialisation methods and connectivity construction are defined using Python strings containing a C-like language called GeNNCode. Users can fully customise these components. GeNN provides extensive documentation and tutorials.
 

--- a/content/english/neuromorphic-computing/software/snn-frameworks/genn/index.md
+++ b/content/english/neuromorphic-computing/software/snn-frameworks/genn/index.md
@@ -1,0 +1,26 @@
+---
+title: "GeNN"
+type: neuromorphic-software
+description: Simulator for SNN models focusing on dynamics, size, structure of neural systems, not on individual neuron morphology.
+logo: nest.png
+website: https://genn-team.github.io/
+dependencies: 
+field_of_application: Neuroscience
+source_code: https://github.com/genn-team/genn
+stars_widget_url: https://img.shields.io/github/stars/genn-team/genn.svg?style=social
+stars: 233
+version_widget_url: https://img.shields.io/github/release/genn-team/genn.svg?label=github%20release
+license: LGPL-2.1
+supports_hardware: False
+supports_NIR: False
+language: C++/Python
+maintainer: James Knight
+draft: false
+---
+
+## Overview
+**GeNN** is a software package to accelerate Spiking Neural Network simulations 
+on hardware including NVIDIA GPUs using code generation. Networks are described using a simple Python API and the models and snippets used to describe the behaviour of the neurons and synapses which make up the networks are easily customised using strings containing a C-like language called GeNNCode. GeNN provides extensive documentation and tutorials.
+
+GeNN focusses on flexibility and performance on a single GPU, providing unique features for offloading initialisation to the GPU and even generating connectivity on the fly, allowing very large models (millions of neurons and billions of synapses to be simulated on a single GPU.
+Because of this flexibility, GeNN has been used across a wide range of applications from simulating large-scale models of cortex to training recurrent SNNs using gradient-based learning for machine learning tasks.

--- a/content/english/neuromorphic-computing/software/snn-frameworks/ml_genn/index.md
+++ b/content/english/neuromorphic-computing/software/snn-frameworks/ml_genn/index.md
@@ -1,0 +1,24 @@
+---
+title: "mlGeNN"
+type: neuromorphic-software
+description: Simulator for SNN models focusing on dynamics, size, structure of neural systems, not on individual neuron morphology.
+logo: nest.png
+website: https://ml-genn.readthedocs.io/en/latest/
+dependencies: 
+field_of_application: Machine learning
+source_code: https://github.com/genn-team/ml_genn
+stars_widget_url: https://img.shields.io/github/stars/genn-team/ml_genn.svg?style=social
+stars: 24
+version_widget_url: https://img.shields.io/github/release/genn-team/ml_genn.svg?label=github%20release
+license: LGPL-2.1
+supports_hardware: False
+supports_NIR: False
+language: Python
+maintainer: James Knight
+draft: false
+---
+
+## Overview
+**mlGeNN** is a new library for machine learning with Spiking Neural Networks (SNNs), built on the efficient foundation provided by our GeNN simulator. mlGeNN expose the constructs required to build SNNs using an API, inspired by modern ML libraries like Keras, which aims to reduce cognitive load by automatically calculating layer sizes, default hyperparameter values etc to enable rapid prototyping of SNN models.
+
+mlGeNN provides user friendly implementations of novel SNN training algorithms such as e-prop and EventProp  to enable spike-based ML on top of GeNN’s GPU-optimised sparse data structures and algorithms.

--- a/content/english/neuromorphic-computing/software/snn-frameworks/ml_genn/index.md
+++ b/content/english/neuromorphic-computing/software/snn-frameworks/ml_genn/index.md
@@ -1,10 +1,10 @@
 ---
 title: "mlGeNN"
 type: neuromorphic-software
-description: Simulator for SNN models focusing on dynamics, size, structure of neural systems, not on individual neuron morphology.
-logo: nest.png
+description: Framework for machine learning with SNNs built on the GeNN simulator. Focused on ease of use in combination with computational efficiency derived from GeNN.
+logo: 
 website: https://ml-genn.readthedocs.io/en/latest/
-dependencies: 
+dependencies: GeNN
 field_of_application: Machine learning
 source_code: https://github.com/genn-team/ml_genn
 stars_widget_url: https://img.shields.io/github/stars/genn-team/ml_genn.svg?style=social
@@ -19,6 +19,8 @@ draft: false
 ---
 
 ## Overview
-**mlGeNN** is a new library for machine learning with Spiking Neural Networks (SNNs), built on the efficient foundation provided by our GeNN simulator. mlGeNN expose the constructs required to build SNNs using an API, inspired by modern ML libraries like Keras, which aims to reduce cognitive load by automatically calculating layer sizes, default hyperparameter values etc to enable rapid prototyping of SNN models.
+**mlGeNN** is a library for machine learning with Spiking Neural Networks (SNNs), built on the efficient foundation of the GeNN simulator. 
 
-mlGeNN provides user friendly implementations of novel SNN training algorithms such as e-prop and EventProp  to enable spike-based ML on top of GeNN’s GPU-optimised sparse data structures and algorithms.
+mlGeNN exposes the constructs required to build SNNs using an API, inspired by modern ML libraries like Keras, which aims to reduce cognitive load by automatically calculating layer sizes, default hyperparameter values etc to enable rapid prototyping of SNN models.
+
+mlGeNN provides user friendly implementations of novel SNN training algorithms such as e-prop and EventProp to enable spike-based ML on top of GeNN’s GPU-optimised sparse data structures and algorithms. This allows better scaling and hence using EventProp at high temporal resolution with thousands of time steps. mlGeNN provides extensive documentation and tutorials.

--- a/content/english/neuromorphic-computing/software/snn-frameworks/ml_genn/index.md
+++ b/content/english/neuromorphic-computing/software/snn-frameworks/ml_genn/index.md
@@ -23,4 +23,4 @@ draft: false
 
 mlGeNN exposes the constructs required to build SNNs using an API, inspired by modern ML libraries like Keras, which aims to reduce cognitive load by automatically calculating layer sizes, default hyperparameter values etc to enable rapid prototyping of SNN models.
 
-mlGeNN provides user friendly implementations of novel SNN training algorithms such as e-prop and EventProp to enable spike-based ML on top of GeNN’s GPU-optimised sparse data structures and algorithms. This allows better scaling and hence using EventProp at high temporal resolution with thousands of time steps. mlGeNN provides extensive documentation and tutorials.
+mlGeNN provides user friendly implementations of novel SNN training algorithms such as e-prop and EventProp to enable spike-based ML on top of GeNN’s GPU-optimised sparse data structures and algorithms. This allows better scaling and, using EventProp, allows training with high temporal resolution and/or thousands of time steps. mlGeNN provides extensive documentation and tutorials.


### PR DESCRIPTION
As discussed by email, @tnowotny and I added descriptions of our GeNN and mlGeNN software to the software section. Although they are obviously related, _we_ think it makes sense to have separate entries for GeNN and mlGeNN as they have different target audiences. Happy to merge together somehow if you'd rather.