### PR TITLE
docs: Remove detailed ways to contribute from getting-involved

### DIFF
--- a/content/getting-involved/index.md
+++ b/content/getting-involved/index.md
@@ -52,56 +52,8 @@ Your contributions, big or small, are the lifeblood of Open Neuromorphic. As you
 
 By engaging in initiatives, you not only help drive the ONM community forward but also develop your own skills, expand your network, and gain valuable experience in the open-source neuromorphic landscape.
 
-## Detailed Ways to Contribute
-
 Beyond these pathways, there are many specific ways you can contribute to ONM:
 
 If you're new to the community, we recommend joining our [Discord](https://discord.gg/C9bzWgNmqk) to connect with other members and learn more about our ongoing projects and initiatives. Leave a message in the `#welcome` channel to introduce yourself and let us know how you'd like to contribute!
 
 One quick and easy way to support our community is by sharing our [website](https://open-neuromorphic.org/) and [Discord](https://discord.gg/C9bzWgNmqk) with your friends and colleagues. We're always looking for new members to join our community. Also, linking to our website helps boost our search engine rankings, which makes it easier for others to find us.
-
-#### Content
-
-##### Blog Posts
-
-- **Share Your Knowledge**: Contribute by writing insightful blog posts.
-- **Open a PR**: Consider opening a pull request for a new blog post.
-- **Topic Ideas**: Find interesting topics in our [issues](https://github.com/open-neuromorphic/open-neuromorphic.github.io/issues) if you need inspiration.
-
-##### Support Workshop Events
-
-- **Event Coordinator**: Help organize and coordinate our workshops and events.
-  - Website: Add new events to our website, and update after the event.
-    - https://github.com/open-neuromorphic/open-neuromorphic.github.io/blob/main/content.md
-    - https://github.com/open-neuromorphic/open-neuromorphic.github.io/tree/main/content/english/workshops
-  - YouTube (highlight recent video, add to playlist, etc.)
-  - Thumbnails creation for events
-  - Promote Events: Share upcoming events on social media and other platforms.
-- **Summaries**: Create summaries of events to help the community catch up on what they missed.
-
-
-##### Neuromorphic Projects
-
-- **Curated List**: Enhance our [curated list of Neuromorphic Projects](/neuromorphic-computing/hardware/) to  showcase the latest developments in the field.
-
-#### Workshop
-
-- **Organize a Workshop**: Share your workshop ideas with the community on Discord. Gather feedback to ensure a successful workshop.
-- **Attend Workshops**: Join our workshops and events to learn more about neuromorphic computing. Provide feedback and suggestions to help us improve.
-
-#### Code
-
-- **Host Your Code**: Boost your project's visibility by hosting it within the ONM organization. You'll receive instant help and feedback from our community.
-- **Migrate Existing Repositories**: Easily migrate an existing repository to our organization.
-
-#### Website Development
-
-- **Hugo CMS**: Contribute to our website's development using Hugo CMS. Join us in expanding our online presence.
-
-#### Documentation
-
-- **Accessibility**: Enhance and expand our documentation to make ONM accessible to everyone.
-
-### Join the Conversation
-
-The easiest way to connect with us is through [Discord](https://discord.gg/C9bzWgNmqk). Join discussions on various topics, including research, job opportunities, open hardware, spiking neural networks, and much more. We're excited to have you on board!


### PR DESCRIPTION
The detailed ways to contribute section was redundant.