### PR TITLE
feat: Add edit page link to page header

### DIFF
--- a/layouts/partials/components/edit-page-link.html
+++ b/layouts/partials/components/edit-page-link.html
@@ -1,0 +1,11 @@
+{{ if and .IsPage .File }}
+  {{ with .File.Path }}
+    {{ $dev_url := printf "https://github.dev/open-neuromorphic/open-neuromorphic.github.io/blob/main/content/%s" . }}
+    <a href="{{ $dev_url }}" target="_blank" rel="noopener"
+       class="btn normal-case inline-flex flex-shrink-0 items-center gap-x-1.5 rounded-md bg-white dark:bg-darkmode-theme-dark !px-2.5 !py-1 text-xs font-semibold text-gray-900 dark:text-gray-200 shadow-sm ring-1 ring-inset ring-gray-300 dark:ring-gray-700 hover:bg-gray-50 dark:hover:bg-black/20 transition-colors">
+      {{ partial "icon.html" (dict "style" "brands" "name" "github" "class" "h-3.5 w-3.5") }}
+      <span>Edit Page</span>
+      {{ partial "icon.html" (dict "style" "solid" "name" "arrow-up-right-from-square" "class" "h-3 w-3") }}
+    </a>
+  {{ end }}
+{{ end }}

--- a/layouts/partials/essentials/footer.html
+++ b/layouts/partials/essentials/footer.html
@@ -89,17 +89,6 @@
       <p>
         {{ site.Params.copyright | markdownify }} | Site Built By: <a href="https://visioninit.dev">VisionInit</a>
       </p>
-      {{ if .IsPage }}
-        {{ with .File }}
-          {{ with .Path }}
-            <p class="mt-2">
-              <a href='https://github.com/open-neuromorphic/open-neuromorphic.github.io/tree/main/content/{{ . }}' target="_blank" rel="noopener">
-                Edit this Page <i class="fab fa-github ml-1"></i>
-              </a>
-            </p>
-          {{ end }}
-        {{ end }}
-      {{ end }}
     </div>
   </div>
 </footer>

--- a/layouts/partials/page-header.html
+++ b/layouts/partials/page-header.html
@@ -3,7 +3,10 @@
     <div>
       <h1 class="mb-3">{{ .Title | title }}</h1>
       <p class="mb-3">{{ .Description }}</p>
-      {{ partial "components/breadcrumb" (dict "Context" . ) }}
+      <div class="flex flex-wrap items-center justify-between gap-y-2">
+        {{ partial "components/breadcrumb" (dict "Context" . ) }}
+        {{ partial "components/edit-page-link.html" . }}
+      </div>
     </div>
   </div>
 </section>


### PR DESCRIPTION
This moves the edit page link from the footer to the page header for better visibility.