### PR TITLE
Profile formatting

### DIFF
--- a/content/contributors/alexander-hadjiivanov/index.md
+++ b/content/contributors/alexander-hadjiivanov/index.md
@@ -6,9 +6,5 @@ social: []
 draft: false
 ---
 Alex is currently a Research Fellow with the Advanced Concepts Team at the European Space Agency. His research focuses on homeostasis, perception and structural plasticity in classical and spiking neural networks. When he has time, he also works on <a href="https://gitlab.com/EuropeanSpaceAgency/pyrception">Pyrception, an easy way to interface various types of input data with neural networks</a>.
-<br><br>
-No single branch of AI can claim the crown of true intelligence on its own. Rather,
-developing AI worthy of the ''I'' would require a concerted effort to combine
-virtually all the branches - from perception through learning and cognition to
-reasoning and interaction. The most enticing aspect of neuromorphic computing
-is its potential to bring about this unification.
+
+No single branch of AI can claim the crown of true intelligence on its own. Rather, developing AI worthy of the ''I'' would require a concerted effort to combine virtually all the branches - from perception through learning and cognition to reasoning and interaction. The most enticing aspect of neuromorphic computing is its potential to bring about this unification.

--- a/content/contributors/alexander-henkes/index.md
+++ b/content/contributors/alexander-henkes/index.md
@@ -5,20 +5,10 @@ image: "alexander-henkes.jpg"
 social: []
 draft: false
 ---
-Alexander Henkes received the B.Sc. (Mechanical Engineering) and M.Sc.
-(Mechanical Engineering) degrees from the University of Paderborn, Germany, in
-2015 and 2018, respectively. In 2022, he received his Ph.D. with honors from the
-Technical University of Braunschweig (TUBS), Germany, for his thesis ''Artificial
-Neural Networks in Continuum Micromechanics''.
+Alexander Henkes received the B.Sc. (Mechanical Engineering) and M.Sc. (Mechanical Engineering) degrees from the University of Paderborn, Germany, in 2015 and 2018, respectively. In 2022, he received his Ph.D. with honors from the Technical University of Braunschweig (TUBS), Germany, for his thesis ''Artificial Neural Networks in Continuum Micromechanics''.
 
-In 2022, he was elected as a junior member of the German Association of Applied
-Mathematics and Mechanics (GAMM) for his outstanding research in the field of
-artificial intelligence in continuum micromechanics. In 2023, he won the ETH Zürich
-Postdoctoral Fellowship and joined the Computational Mechanics group at ETH as
-a postdoc.
+In 2022, he was elected as a junior member of the German Association of Applied Mathematics and Mechanics (GAMM) for his outstanding research in the field of artificial intelligence in continuum micromechanics. In 2023, he won the ETH Zürich Postdoctoral Fellowship and joined the Computational Mechanics group at ETH as a postdoc.
 
-His current research focuses on spiking neural networks (SNN). Recently, he published
-a preprint on nonlinear history-dependent regression using SNN. This enables SNN
-to be used in the context of applied mathematics and computational engineering.
+His current research focuses on spiking neural networks (SNN). Recently, he published a preprint on nonlinear history-dependent regression using SNN. This enables SNN to be used in the context of applied mathematics and computational engineering.
 
 He is a contributor of [snnTorch](https://github.com/jeshraghian/snntorch).

--- a/content/contributors/catherine-schuman/index.md
+++ b/content/contributors/catherine-schuman/index.md
@@ -5,15 +5,6 @@ image: "catherine-schuman.jpg"
 social: []
 draft: false
 ---
-Catherine (Katie) Schuman is an Assistant Professor in the Department
-of Electrical Engineering and Computer Science at the University of Tennessee
-(UT). She received her Ph.D. in Computer Science from UT in 2015, where she completed
-her dissertation on the use of evolutionary algorithms to train spiking neural
-networks for neuromorphic systems. Katie previously served as a research scientist
-at Oak Ridge National Laboratory, where her research focused on algorithms and
-applications of neuromorphic systems.
+Catherine (Katie) Schuman is an Assistant Professor in the Department of Electrical Engineering and Computer Science at the University of Tennessee (UT). She received her Ph.D. in Computer Science from UT in 2015, where she completed her dissertation on the use of evolutionary algorithms to train spiking neural networks for neuromorphic systems. Katie previously served as a research scientist at Oak Ridge National Laboratory, where her research focused on algorithms and applications of neuromorphic systems.
 
-
-Katie co-leads the TENNLab Neuromorphic Computing Research Group at UT. She has
-over 100 publications as well as seven patents in the field of neuromorphic computing.
-She received the Department of Energy Early Career Award in 2019.
+Katie co-leads the TENNLab Neuromorphic Computing Research Group at UT. She has over 100 publications as well as seven patents in the field of neuromorphic computing. She received the Department of Energy Early Career Award in 2019.

--- a/content/contributors/charlotte-frenkel/index.md
+++ b/content/contributors/charlotte-frenkel/index.md
@@ -5,20 +5,13 @@ image: "charlotte-frenkel.jpg" # Assuming charlotte-frenkel.jpg is in this bundl
 social: [] # Add social links if available, e.g., { icon: "fa-brands fa-github", link: "https://github.com/ChFrenkel", title: "github" }
 draft: false
 ---
-Charlotte Frenkel is an Assistant Professor at the Microelectronics
-department of Delft University of Technology, Delft, The Netherlands.
+Charlotte Frenkel is an Assistant Professor at the Microelectronics department of Delft University of Technology, Delft, The Netherlands.
 
 Her research goals are:
 
-- to demonstrate a competitive advantage for neuromorphic computing devices compared
-to conventional neural network accelerators,
+- to demonstrate a competitive advantage for neuromorphic computing devices compared to conventional neural network accelerators,
+- to uncover a framework toward on-chip neuromorphic intelligence for adaptive edge computing.
 
-- to uncover a framework toward on-chip neuromorphic intelligence for adaptive
-edge computing.
+To achieve these goals, she is investigating both the bottom-up and the top-down design approaches, as well as their synergies.
 
-
-To achieve these goals, she is investigating both the bottom-up and the top-down
-design approaches, as well as their synergies.
-
-She is the designer of the [ODIN](https://github.com/ChFrenkel/ODIN) and [ReckOn](https://github.com/ChFrenkel/ReckOn)
-open-source online-learning digital neuromorphic processors.
+She is the designer of the [ODIN](https://github.com/ChFrenkel/ODIN) and [ReckOn](https://github.com/ChFrenkel/ReckOn) open-source online-learning digital neuromorphic processors.

--- a/content/contributors/henning-wessels/index.md
+++ b/content/contributors/henning-wessels/index.md
@@ -5,10 +5,4 @@ image: "henning-wessels.jpg" # Assuming henning-wessels.jpg is in this bundle
 social: []
 draft: false
 ---
-Henning Wessels is Assistant Professor at the Department of Civil and
-Environmental Engineering, Technical University Braunschweig, where he is leading
-the data-driven modeling group. His group is developing computational methods
-at the intersection of mechanics, numerics, machine learning and uncertainty quantification.
-Applications can be found, for instance, in virtual sensing and structural health
-monitoring. Here, SNN offer huge potential for data-driven mechanics on neuromorphic
-hardware within embedded systems.
+Henning Wessels is Assistant Professor at the Department of Civil and Environmental Engineering, Technical University Braunschweig, where he is leading the data-driven modeling group. His group is developing computational methods at the intersection of mechanics, numerics, machine learning and uncertainty quantification. Applications can be found, for instance, in virtual sensing and structural health monitoring. Here, SNN offer huge potential for data-driven mechanics on neuromorphic hardware within embedded systems.

--- a/content/contributors/konrad-kording/index.md
+++ b/content/contributors/konrad-kording/index.md
@@ -5,5 +5,4 @@ image: "konrad-kording.jpg"
 social: []
 draft: false
 ---
-Konrad Kording runs his lab at the University of Pennsylvania. Konrad is interested in the question of how the brain solves the credit assignment problem and similarly how we should assign credit in the real world (through causality).
-In extension of this main thrust he is interested in applications of causality in biomedical research. Konrad has trained as student at ETH Zurich with Peter Konig, as postdoc at UCL London with Daniel Wolpert and at MIT with Josh Tenenbaum. After a decade at Northwestern University, he is now PIK professor at UPenn.
+Konrad Kording runs his lab at the University of Pennsylvania. Konrad is interested in the question of how the brain solves the credit assignment problem and similarly how we should assign credit in the real world (through causality). In extension of this main thrust he is interested in applications of causality in biomedical research. Konrad has trained as student at ETH Zurich with Peter Konig, as postdoc at UCL London with Daniel Wolpert and at MIT with Josh Tenenbaum. After a decade at Northwestern University, he is now PIK professor at UPenn.


### PR DESCRIPTION
Some of the profiles had extra line breaks that made them look a odd on display. I think in an older version of the site this wasn't an issue (as formatting worked a bit different to allow parsing of katex, but now we have a math widget to handle those cases) 