### PR TITLE
feat: Add weekly town hall event

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: Deploy Hugo site to Pages
 
 on:
   push:
-    branches: ["main", "collaboration-network"]
+    branches: ["main", "townhall-and-hacking-hours"]
 
 
 permissions:

--- a/content/getting-involved/town-hall/_index.md
+++ b/content/getting-involved/town-hall/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Community Town Hall"
+description: "Join our weekly Open Neuromorphic Town Hall to catch up on the latest community news, discuss ongoing initiatives, and share your ideas."
+---
+
+## What is the Town Hall?
+
+The Open Neuromorphic Town Hall is a weekly meeting for the entire community. It serves as a replacement for the general recurring Hacking Hours, providing a dedicated space for us to connect, align, and discuss the direction of ONM.
+
+These sessions are an opportunity to:
+-   Get updates on ongoing initiatives from the Executive Committee and community leads.
+-   Discuss new ideas and proposals.
+-   Ask questions and provide feedback directly.
+-   Connect with other members of the neuromorphic community.
+
+This is your chance to get involved in the conversation and help shape the future of Open Neuromorphic.
+
+## When & Where
+
+The Town Hall is held every week at the following time:
+
+-   **When:** Mondays at 14:00 CEST (8:00 AM EST)
+-   **Where:** Live on the "Town Hall" voice channel on our [Discord Server](https://discord.gg/hUygPUdD8E).
+
+Everyone is welcome to join, listen in, and participate. We look forward to seeing you there!

--- a/content/getting-involved/town-hall/_index.md
+++ b/content/getting-involved/town-hall/_index.md
@@ -5,7 +5,8 @@ description: "Join our weekly Open Neuromorphic Town Hall to catch up on the lat
 
 ## What is the Town Hall?
 
-The Open Neuromorphic Town Hall is a weekly meeting for the entire community. It serves as a replacement for the general recurring Hacking Hours, providing a dedicated space for us to connect, align, and discuss the direction of ONM.
+The Open Neuromorphic Town Hall is a weekly meeting for the entire community. 
+It serves to provide a dedicated space for us to connect, align, and discuss the direction of ONM.
 
 These sessions are an opportunity to:
 -   Get updates on ongoing initiatives from the Executive Committee and community leads.

--- a/data/recurring_events.toml
+++ b/data/recurring_events.toml
@@ -6,8 +6,6 @@ description = """
 Are you interested in neuromorphics and want to contribute to the open source community? ✨
 Then join the community coding sessions where we improve the neuromorphic software ecosystem, one issue at the time 🚀
 
-We'll meet every Monday from 16-18 CET on the Open Neuromorphic Discord server.
-
 Active projects and issues that need help are listed here: https://github.com/open-neuromorphic/coding
 """
 day_of_week = "Monday" # Case-sensitive, full day name
@@ -17,5 +15,22 @@ time_zone = "CEST"      # Or "CEST" as appropriate. Be mindful of DST.
 location_name = "Open Neuromorphic Discord"
 location_url = "https://discord.gg/hUygPUdD8E"
 details_page_link = "/neuromorphic-computing/software/hacking-hours/" # Link to the main Hacking Hours page
-active = true      # If false, this event won't be shown as upcoming
+active = false      # DEACTIVATED: This event will no longer appear as recurring
 image = "/images/hacking-hours-default-banner.png" # Optional default image
+
+[[events]]
+id = "town-hall" # Unique ID for this new recurring event
+title = "ONM Weekly Town Hall"
+host = "Jens E. Pedersen & ONM Community"
+description = """
+Join our weekly Town Hall to discuss community updates, propose new ideas, and connect with other members. This is an open forum for everyone in the Open Neuromorphic community.
+"""
+day_of_week = "Monday"
+start_time = "14:00"   # 2PM CEST
+end_time = "15:00"     # Assuming 1 hour
+time_zone = "CEST"
+location_name = "Open Neuromorphic Discord"
+location_url = "https://discord.gg/hUygPUdD8E"
+details_page_link = "/getting-involved/town-hall/"
+active = true
+image = "/images/getting-involved/getting-involved-og.jpg"

--- a/layouts/partials/hacking-hours-sidebar.html
+++ b/layouts/partials/hacking-hours-sidebar.html
@@ -4,7 +4,7 @@
 <div class="px-7 pt-7 content-panel">
   <h3 class="pb-5 pt-5 text-xl">Next Hacking Hour</h3>
   {{ $recurringEventData := site.Data.recurring_events.events }}
-  {{ $hackingHourEvent := "" }}
+  {{ $hackingHourEvent := false }}
   {{ range $recurringEventData }}
     {{ if and (eq .id "hacking-hours") .active }}
       {{ $hackingHourEvent = . }}
@@ -49,6 +49,9 @@
         </div>
       </div>
     </div>
+    <div class="text-right pb-5 pt-5">
+      <a href="{{ $hackingHourEvent.location_url | default "https://discord.gg/hUygPUdD8E" }}" target="_blank" class="btn btn-new-primary btn-sm">Join on Discord</a>
+    </div>
   {{ else }}
     <p class="text-sm text-gray-600 dark:text-gray-400 mb-4">
       Hacking Hours are currently on a break. Check back soon for the new schedule!
@@ -56,9 +59,8 @@
     <p class="text-sm text-gray-600 dark:text-gray-400 mb-4">
       In the meantime, join our Discord to connect with the community and see what others are working on.
     </p>
+    <div class="text-right pb-5 pt-5">
+      <a href="https://discord.gg/hUygPUdD8E" target="_blank" class="btn btn-new-primary btn-sm">Join on Discord</a>
+    </div>
   {{ end }}
-
-  <div class="text-right pb-5 pt-5">
-    <a href="{{ $hackingHourEvent.location_url | default "https://discord.gg/hUygPUdD8E" }}" target="_blank" class="btn btn-new-primary btn-sm">Join on Discord</a>
-  </div>
 </div>

--- a/layouts/partials/logic/get_sorted_upcoming_events.html
+++ b/layouts/partials/logic/get_sorted_upcoming_events.html
@@ -37,6 +37,13 @@
         {{ end }}
       {{ end }}
     {{ $nextOccurrenceDate := $now.AddDate 0 0 (int $daysToAdd) }}
+    
+    {{ $detailsPage := "" }}
+    {{ with .details_page_link }}
+      {{ $pagePath := strings.TrimSuffix "/" . | strings.TrimPrefix "/" }}
+      {{ $detailsPage = site.GetPage $pagePath }}
+    {{ end }}
+    
     {{ $allUpcomingEvents = $allUpcomingEvents | append (dict
         "Title" .title
         "Description" .description
@@ -44,7 +51,7 @@
         "StartTime" .start_time
         "EndTime" .end_time
         "TimeZone" .time_zone
-        "Permalink" (.details_page_link | relLangURL)
+        "Permalink" (cond (ne $detailsPage nil) $detailsPage.RelPermalink (.details_page_link | relLangURL))
         "IsRecurring" true
         "Host" .host
         "LocationName" .location_name


### PR DESCRIPTION
Staging at: https://neural-loop.github.io/open-neuromorphic.github.io/

### Description

This change allows for more curated and promoted Hacking Hour sessions while providing a consistent, open forum for community engagement via the Town Hall.

---

### Key Changes

1.  **Hacking Hours are now Individual Events:**
    *   The recurring "Hacking Hours" entry in `data/recurring_events.toml` has been deactivated.
    *   This means new Hacking Hours will be created as standalone content pages, just like Workshops and Student Talks.
    *   The sidebar on the Hacking Hours pages has been updated to reflect that the general recurring session is on break, guiding users to check the page for individually scheduled events.

2.  **New Weekly Community Town Hall:**
    *   A new recurring event, the "ONM Weekly Town Hall," has been added to `data/recurring_events.toml`.
    *   A dedicated landing page has been created at `/getting-involved/town-hall/` to explain the purpose and schedule of the new meeting.
    *   This Town Hall will now appear in the "Upcoming Events" sections across the website.

### New Workflow for Contributors

This update changes how Hacking Hours are organized and published. The new process provides better visibility for hosts and topics:

*   **Content Creation:** To schedule a new Hacking Hour, a contributor must create a new Markdown file under `content/neuromorphic-computing/software/hacking-hours/`.
*   **Contributor Profiles:** All hosts and guests for a Hacking Hour must have a corresponding contributor profile under `content/contributors/` to be properly credited and linked on the event page.

