### PR TITLE
fix: Update dotenv version and improve URL handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@tailwindcss/forms": "^0.5.10",
         "@tailwindcss/typography": "^0.5.10",
         "autoprefixer": "^10.4.21",
-        "dotenv": "^17.0.0",
+        "dotenv": "^17.2.2",
         "mime-types": "^3.0.1",
         "postcss": "^8.5.4",
         "postcss-cli": "^11.0.1",
@@ -884,9 +884,9 @@
       "dev": true
     },
     "node_modules/dotenv": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.0.0.tgz",
-      "integrity": "sha512-A0BJ5lrpJVSfnMMXjmeO0xUnoxqsBHWCoqqTnGwGYVdnctqXXUEhJOO7LxmgxJon9tEZFGpe0xPRX0h2v3AANQ==",
+      "version": "17.2.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.2.tgz",
+      "integrity": "sha512-Sf2LSQP+bOlhKWWyhFsn0UsfdK/kCWRv1iuA2gXAwt3dyNabr6QSj00I2V10pidqz69soatm9ZwZvpQMTIOd5Q==",
       "dev": true,
       "engines": {
         "node": ">=12"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@tailwindcss/forms": "^0.5.10",
     "@tailwindcss/typography": "^0.5.10",
     "autoprefixer": "^10.4.21",
-    "dotenv": "^17.0.0",
+    "dotenv": "^17.2.2",
     "mime-types": "^3.0.1",
     "postcss": "^8.5.4",
     "postcss-cli": "^11.0.1",


### PR DESCRIPTION
This commit updates the dotenv package to version 17.2.2 and improves URL handling in fetchGithubStars.js to correctly parse repo paths. It also adds try/catch for handling invalide URLs.