### PR TITLE
fix: Update links to reflect Mission Board rename

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ For a more user-friendly overview of how to get involved with the community, ple
 
 ## Finding a Task: The Mission Board
 
-If you're looking for high-impact ways to contribute to the broader open-source neuromorphic ecosystem, a great place to start is our **[Community Coding Projects](https://open-neuromorphic.org/getting-involved/community-coding-projects/)**. This page lists critical "help wanted" issues from key projects in our community, offering a direct path to making a meaningful contribution.
+If you're looking for high-impact ways to contribute to the broader open-source neuromorphic ecosystem, a great place to start is our **[Mission Board](https://open-neuromorphic.org/getting-involved/solving-neuromorphic-computings-key-challenges/)**. This page lists critical "help wanted" issues from key projects in our community, offering a direct path to making a meaningful contribution.
 
 ## Getting Started: Local Development Setup
 
@@ -201,6 +201,6 @@ Please follow a conventional commit format to keep the history clean and underst
 
 ---
 
-If you're looking for high-impact ways to contribute to the broader open-source neuromorphic ecosystem, a great place to start is our **[Community Coding Projects](https://open-neuromorphic.org/getting-involved/community-coding-projects/)**. This page lists critical "help wanted" issues from key projects in our community, offering a direct path to making a meaningful contribution.
+If you're looking for high-impact ways to contribute to the broader open-source neuromorphic ecosystem, a great place to start is our **[Mission Board](https://open-neuromorphic.org/getting-involved/solving-neuromorphic-computings-key-challenges/)**. This page lists critical "help wanted" issues from key projects in our community, offering a direct path to making a meaningful contribution.
 
 Thank you again for your interest in contributing. We look forward to your pull requests!

--- a/content/getting-involved/_index.md
+++ b/content/getting-involved/_index.md
@@ -25,7 +25,7 @@ cta_link="/volunteer-opportunities/"
 image="developer-path.jpeg"
 alt_text="Developers collaborating on code"
 layout_class="reverse"
-explore_links="Key Challenges Mission Board|/getting-involved/solving-neuromorphic-computings-key-challenges/;Join an Initiative|/neuromorphic-computing/initiatives/;Attend Hacking Hours|/neuromorphic-computing/software/hacking-hours/;Contribute on GitHub|https://github.com/open-neuromorphic;Community Coding Projects|/getting-involved/community-coding-projects/"
+explore_links="Key Challenges Mission Board|/getting-involved/solving-neuromorphic-computings-key-challenges/;Join an Initiative|/neuromorphic-computing/initiatives/;Attend Hacking Hours|/neuromorphic-computing/software/hacking-hours/;Contribute on GitHub|https://github.com/open-neuromorphic"
 >}}
 
 {{< pathway_card

--- a/content/supporters/_index.md
+++ b/content/supporters/_index.md
@@ -51,7 +51,7 @@ If your project, lab, or company is interested in joining our mission, we would 
 
 ### Sponsoring Open-Source Development
 
-Supporting the open-source tools that power neuromorphic research is one of the most impactful ways to accelerate the entire field. When you click the "Sponsor" button on our [Community Coding Projects board](/getting-involved/solving-neuromorphic-computings-key-challenges/), you are showing interest in funding a solution. Here’s how you can help:
+Supporting the open-source tools that power neuromorphic research is one of the most impactful ways to accelerate the entire field. When you click the "Sponsor" button on our [Mission Board](/getting-involved/solving-neuromorphic-computings-key-challenges/), you are showing interest in funding a solution. Here’s how you can help:
 
 **1. Sponsor Projects Directly**
 

--- a/layouts/shortcodes/community_projects_mini_board.html
+++ b/layouts/shortcodes/community_projects_mini_board.html
@@ -29,6 +29,6 @@
   </div>
 
   <div class="flex-shrink-0 text-center p-3 border-t border-border dark:border-darkmode-border bg-white/50 dark:bg-black/20">
-    <a href="{{ "getting-involved/community-coding-projects/" | relLangURL }}" class="btn btn-sm btn-new-primary">View Full Project Board</a>
+    {{ $p := site.GetPage "getting-involved/solving-neuromorphic-computings-key-challenges" }}<a href="{{ $p.RelPermalink }}" class="btn btn-sm btn-new-primary">View All Challenges</a>
   </div>
 </div>


### PR DESCRIPTION
Some old links pointed to 'community issues' rather than mission board.