### PR TITLE
Fix broken product page link for TSP1 entry

### DIFF
--- a/content/neuromorphic-computing/hardware/tsp1-time-series-processor-applied-brain-research/index.md
+++ b/content/neuromorphic-computing/hardware/tsp1-time-series-processor-applied-brain-research/index.md
@@ -9,7 +9,7 @@ organization:
   org_logo: abr.png
   org_name: Applied Brain Research
   org_website: https://www.appliedbrainresearch.com/
-  product_page_link: https://www.appliedbrainresearch.com/product
+  product_page_link: https://www.appliedbrainresearch.com/state-space-accelerator
   social_media_links:
     linkedin: https://www.linkedin.com/company/applied-brain-research/
     twitter: https://x.com/abr_inc


### PR DESCRIPTION
Previous link returns 404 (https://www.appliedbrainresearch.com/product)