### PR TITLE
Software display

### DIFF
--- a/archetypes/neuromorphic-software.md
+++ b/archetypes/neuromorphic-software.md
@@ -10,10 +10,7 @@ website: "https://official-website.com"
 dependencies: "Key dependencies (e.g., PyTorch, JAX, NumPy, C++17)"
 field_of_application: "e.g., Machine Learning, Neuroscience, Data Processing, Hardware Interface, Robotics"
 source_code: "https://github.com/org/repo" # This URL is now used to automatically fetch the star count for sorting.
-# To display the version, use one of the following. `pypi_id` is preferred for PyPI packages.
-# Use `version_badge_url_override` for custom badges (e.g., from GitHub releases or other registries).
-pypi_id: "" # e.g., "snntorch". This will auto-generate a PyPI version badge.
-# version_badge_url_override: "" # e.g., "https://img.shields.io/github/v/release/user/repo"
+pypi_id: "" # e.g., "snntorch". Leave empty if not applicable.
 license: "e.g., MIT, GPL-3.0, AGPL-3.0, Apache-2.0, custom"
 supports_hardware: false # Set to true if it directly supports or deploys to neuromorphic hardware platforms
 supports_NIR: false # Set to true if it supports the Neuromorphic Intermediate Representation

--- a/layouts/partials/components/software-list.html
+++ b/layouts/partials/components/software-list.html
@@ -61,16 +61,6 @@
           {{ $repo_path = replace $repo_path ".git" "" }}
           {{ end }}
 
-          {{ if $page.Params.version_badge_url_override }}
-          <img class="h-5" src="{{ $page.Params.version_badge_url_override }}" alt="Version Badge">
-          {{ else if $page.Params.pypi_id }}
-          <img class="h-5" src="https://img.shields.io/pypi/v/{{ $page.Params.pypi_id }}.svg" alt="PyPI Version">
-          {{ else if $is_github }}
-          <img class="h-5" src="https://img.shields.io/github/last-commit/{{ $repo_path }}?label=last%20commit" alt="GitHub Last Commit">
-          {{ else if $is_gitlab }}
-          <img class="h-5" src="https://img.shields.io/gitlab/last-commit/{{ $repo_path }}?label=last%20commit" alt="GitLab Last Commit">
-          {{ end }}
-
           {{ if $is_github }}
           <img class="h-5" src="https://img.shields.io/github/stars/{{ $repo_path }}.svg?style=social" alt="GitHub Stars">
           {{ else if $is_gitlab }}

--- a/layouts/partials/components/software-list.html
+++ b/layouts/partials/components/software-list.html
@@ -66,7 +66,9 @@
           {{ else if $page.Params.pypi_id }}
           <img class="h-5" src="https://img.shields.io/pypi/v/{{ $page.Params.pypi_id }}.svg" alt="PyPI Version">
           {{ else if $is_github }}
-          <img class="h-5" src="https://img.shields.io/github/v/release/{{ $repo_path }}" alt="GitHub Release">
+          <img class="h-5" src="https://img.shields.io/github/last-commit/{{ $repo_path }}?label=last%20commit" alt="GitHub Last Commit">
+          {{ else if $is_gitlab }}
+          <img class="h-5" src="https://img.shields.io/gitlab/last-commit/{{ $repo_path }}?label=last%20commit" alt="GitLab Last Commit">
           {{ end }}
 
           {{ if $is_github }}

--- a/layouts/partials/software/at-a-glance.html
+++ b/layouts/partials/software/at-a-glance.html
@@ -41,20 +41,10 @@
     {{ $repo_path = replace $repo_path ".git" "" }}
     {{ end }}
 
-    {{ if .version_badge_url_override }}
-    <img src="{{ .version_badge_url_override }}" alt="Version Badge" class="inline-block h-5">
-    {{ else if .pypi_id }}
-    <img src="https://img.shields.io/pypi/v/{{ .pypi_id }}.svg" alt="PyPI Version" class="inline-block h-5">
-    {{ else if $is_github }}
-    <img src="https://img.shields.io/github/last-commit/{{ $repo_path }}?label=last%20commit" alt="GitHub Last Commit" class="inline-block h-5">
-    {{ else if $is_gitlab }}
-    <img src="https://img.shields.io/gitlab/last-commit/{{ $repo_path }}?label=last%20commit" alt="GitLab Last Commit" class="inline-block h-5">
-    {{ end }}
-
     {{ if $is_github }}
     <img src="https://img.shields.io/github/stars/{{ $repo_path }}.svg?style=social" alt="GitHub Stars" class="inline-block h-5">
     {{ else if $is_gitlab }}
-    <img src="https://img.shields.io/gitlab/stars/{{ $repo_path }}.svg?style=social" alt="GitLab Stars">
+    <img src="https://img.shields.io/gitlab/stars/{{ $repo_path }}.svg?style=social" alt="GitLab Stars" class="inline-block h-5">
     {{ end }}
   </div>
 

--- a/layouts/partials/software/at-a-glance.html
+++ b/layouts/partials/software/at-a-glance.html
@@ -46,7 +46,9 @@
     {{ else if .pypi_id }}
     <img src="https://img.shields.io/pypi/v/{{ .pypi_id }}.svg" alt="PyPI Version" class="inline-block h-5">
     {{ else if $is_github }}
-    <img src="https://img.shields.io/github/v/release/{{ $repo_path }}" alt="GitHub Release" class="inline-block h-5">
+    <img src="https://img.shields.io/github/last-commit/{{ $repo_path }}?label=last%20commit" alt="GitHub Last Commit" class="inline-block h-5">
+    {{ else if $is_gitlab }}
+    <img src="https://img.shields.io/gitlab/last-commit/{{ $repo_path }}?label=last%20commit" alt="GitLab Last Commit" class="inline-block h-5">
     {{ end }}
 
     {{ if $is_github }}


### PR DESCRIPTION
Remove badges - they were superficial (showing pypi version id, or release number based on a badge) and created complexity in the hugo front matter that isn't worth trying to explain to contributors.