### PR TITLE
First ever Rust crate for SNNs

### DIFF
--- a/content/neuromorphic-computing/software/snn-frameworks/rust-snns/index.md
+++ b/content/neuromorphic-computing/software/snn-frameworks/rust-snns/index.md
@@ -20,4 +20,4 @@ draft: false
 ## Overview
 **Rust SNNs** is a Rust crate designed for spiking neural network simulations with neurotransmission, spike trains, spike-timing–dependent plasticity (STDP), attractors, reward-modulated dynamics and lattice-connected neurons. Rust SNNs includes models of LIF, Hodgkin–Huxley and Izhikevich neurons.
 
-It uses traits to describe neuron and synapse dynamics and it can be extended it with custom neurotransmitters, receptors or neuron models while staying strongly typed.
+It uses traits to describe neuron and synapse dynamics and it can be extended with custom neurotransmitters, receptors or neuron models while staying strongly typed.


### PR DESCRIPTION
In my opinion this is a huge breakthrough that I myself planned to create but apparently I was too late and now we can help this creator in building it together as it is on the Apache 2.0 license. There are already over 3570 commits in the repository of this library (crate).

I named this library "Rust SNNs" as its crate name is simply "spiking_neural_networks" and it is made in Rust so it differs from the previous Python and C++ solutions in our field. I might contact the developer and show him NIR.

Attached is another interesting SNN + Rust thing that I discovered today: https://gist.github.com/ruvnet/ec75041bf3cf1c6ce8c18fc0ba1d967d