### PR TITLE
Support manual official_gcal injection for RSVP capabilities

### DIFF
--- a/content/workshops/vector-symbolic-algebras-neural-computation-michael-furlong/index.md
+++ b/content/workshops/vector-symbolic-algebras-neural-computation-michael-furlong/index.md
@@ -3,11 +3,8 @@ title: "Vector Symbolic Algebras and Neural Computation"
 author:
   - "Michael Furlong"
 date: 2026-07-09
-start_datetime: "2026-07-09T18:00:00+02:00"
-end_datetime: "2026-07-09T19:00:00+02:00"
 time_zone: "CEST"
 description: "Join Dr. Michael Furlong to explore Vector Symbolic Algebras (VSAs), how they unify symbolic reasoning with connectionist models, and their computational benefits."
-video: "tcXCnWeyoq0"
 image: "vsa-workshop-banner.png"
 type: "workshops"
 production_credits:
@@ -15,6 +12,12 @@ production_credits:
      role: "Host"
    - name: "Justin Riddiough"
      role: "Event Operations"
+start_datetime: "2026-07-09T18:00:00+02:00"
+end_datetime: "2026-07-09T19:00:00+02:00"
+upcoming: true
+video: "tcXCnWeyoq0"
+official_gcal: "https://calendar.app.google/zMBePU46dhMsmSki9"
+discord_event_url: "https://discord.com/events/1044548629622439977/1524720594820661312"
 ---
 
 Vector Symbolic Algebras (VSAs) are a family of frameworks developed to unify symbolic reasoning and connectionist models. In this way, they provide a rigorous way to talk about neural computation. While VSAs may appear a niche interest at first blush, they have ties to other well-established models of computation.

--- a/layouts/partials/components/metadata-bar.html
+++ b/layouts/partials/components/metadata-bar.html
@@ -95,7 +95,7 @@
           {{ end }}
           {{ if not $event_url }}{{ $event_url = "https://www.youtube.com/@openneuromorphic" }}{{ end }}
 
-          {{ $urls := partial "logic/get-calendar-urls.html" (dict "Title" $ctx.Title "Description" $ctx.Description "Permalink" $ctx.Permalink "Start" $times.Start "End" $times.End "Location" $event_url) }}
+          {{ $urls := partial "logic/get-calendar-urls.html" (dict "Title" $ctx.Title "Description" $ctx.Description "Permalink" $ctx.Permalink "Start" $times.Start "End" $times.End "Location" $event_url "OfficialGcal" $ctx.Params.official_gcal) }}
 
           <div class="flex items-center gap-4 {{ if $hasResources }}border-l border-border dark:border-darkmode-border pl-4 my-1{{ end }}">
             <a href="{{ $event_url }}" target="_blank" rel="noopener" class="font-semibold text-sm text-primary dark:text-darkmode-primary hover:underline flex items-center whitespace-nowrap">

--- a/layouts/partials/homepage/whats-new.html
+++ b/layouts/partials/homepage/whats-new.html
@@ -101,7 +101,7 @@
                     View Details {{ partial "icon.html" (dict "style" "solid" "name" "arrow-right" "class" "ml-1.5") }}
                   </a>
 
-                  {{ $urls := partial "logic/get-calendar-urls.html" (dict "Title" $event.Title "Description" $event.Description "Permalink" $event.Permalink "Start" $event.RawStart "End" $event.RawEnd "Location" $event.LocationURL) }}
+                  {{ $urls := partial "logic/get-calendar-urls.html" (dict "Title" $event.Title "Description" $event.Description "Permalink" $event.Permalink "Start" $event.RawStart "End" $event.RawEnd "Location" $event.LocationURL "OfficialGcal" $event.OfficialGcal) }}
                   {{ partial "components/add-to-calendar.html" (dict "urls" $urls "filename" (printf "%s.ics" ($event.Title | urlize)) "text_class" "text-sm md:text-base font-bold") }}
                 </div>
 
@@ -192,7 +192,7 @@
                       View Details {{ partial "icon.html" (dict "style" "solid" "name" "arrow-right" "class" "ml-1") }}
                     </a>
 
-                    {{ $urls := partial "logic/get-calendar-urls.html" (dict "Title" .Title "Description" .Description "Permalink" .Permalink "Start" .RawStart "End" .RawEnd "Location" .LocationURL) }}
+                    {{ $urls := partial "logic/get-calendar-urls.html" (dict "Title" .Title "Description" .Description "Permalink" .Permalink "Start" .RawStart "End" .RawEnd "Location" .LocationURL "OfficialGcal" .OfficialGcal) }}
                     {{ partial "components/add-to-calendar.html" (dict "urls" $urls "filename" (printf "%s.ics" (.Title | urlize)) "text_class" "text-xs font-semibold") }}
                   </div>
 

--- a/layouts/partials/homepage/whats-new/upcoming-events.html
+++ b/layouts/partials/homepage/whats-new/upcoming-events.html
@@ -72,7 +72,7 @@
           View Details {{ partial "icon.html" (dict "style" "solid" "name" "arrow-right" "class" "ml-1") }}
         </a>
 
-        {{ $urls := partial "logic/get-calendar-urls.html" (dict "Title" .Title "Description" .Description "Permalink" .Permalink "Start" .RawStart "End" .RawEnd "Location" .LocationURL) }}
+        {{ $urls := partial "logic/get-calendar-urls.html" (dict "Title" .Title "Description" .Description "Permalink" .Permalink "Start" .RawStart "End" .RawEnd "Location" .LocationURL "OfficialGcal" .OfficialGcal) }}
         {{ partial "components/add-to-calendar.html" (dict "urls" $urls "filename" (printf "%s.ics" (.Title | urlize)) "text_class" "text-xs font-semibold") }}
       </div>
     </div>

--- a/layouts/partials/logic/get-calendar-urls.html
+++ b/layouts/partials/logic/get-calendar-urls.html
@@ -1,12 +1,13 @@
 {{- /*
   Generates Google, Outlook, and ICS calendar URLs.
-  Expects dict: Title, Description, Permalink, Start (time.Time), End (time.Time), Location (string, optional)
+  Expects dict: Title, Description, Permalink, Start (time.Time), End (time.Time), Location (string, optional), OfficialGcal (string, optional)
 */ -}}
 {{- $start_utc_compact := .Start.UTC.Format "20060102T150405Z" -}}
 {{- $end_utc_compact := .End.UTC.Format "20060102T150405Z" -}}
 {{- $start_utc_iso := .Start.UTC.Format "2006-01-02T15:04:05Z" -}}
 {{- $end_utc_iso := .End.UTC.Format "2006-01-02T15:04:05Z" -}}
 {{- $location := .Location | default "" -}}
+{{- $official_gcal := .OfficialGcal | default "" -}}
 
 {{- $title := .Title | urlquery -}}
 {{- $descriptionText := printf "%s\n\nMore info: %s" .Description .Permalink -}}
@@ -17,6 +18,10 @@
 {{- $locationEncoded := $location | urlquery -}}
 
 {{- $googleUrl := printf "https://calendar.google.com/calendar/render?action=TEMPLATE&text=%s&dates=%s/%s&details=%s&location=%s" $title $start_utc_compact $end_utc_compact $descriptionEncoded $locationEncoded -}}
+{{- if $official_gcal -}}
+  {{- $googleUrl = $official_gcal -}}
+{{- end -}}
+
 {{- $outlookUrl := printf "https://outlook.live.com/calendar/0/deeplink/compose?path=/calendar/action/compose&rru=addevent&subject=%s&startdt=%s&enddt=%s&body=%s&location=%s" $title $start_utc_iso $end_utc_iso $descriptionEncoded $locationEncoded -}}
 
 {{- $safeDesc := .Description | plainify | replaceRE "(\r\n|\n)" " " -}}

--- a/layouts/partials/logic/get-sorted-upcoming-events.html
+++ b/layouts/partials/logic/get-sorted-upcoming-events.html
@@ -26,6 +26,7 @@
       "Image" .Params.image
       "EventType" (.Type | humanize | title)
       "LocationURL" $location
+      "OfficialGcal" .Params.official_gcal
       ) -}}
   {{- end -}}
 {{- end -}}
@@ -36,7 +37,9 @@
     {{- $next := partial "logic/get-next-occurrence-date.html" . -}}
 
     {{- $detailsPage := "" -}}
-    {{- /* ... */ -}}
+    {{- with site.GetPage .details_page_link -}}
+      {{- $detailsPage = . -}}
+    {{- end -}}
 
     {{- $allUpcomingEvents = $allUpcomingEvents | append (dict
       "Title" .title
@@ -47,13 +50,14 @@
       "StartTime" ($next.Start.Format "3:04 PM")
       "EndTime" ($next.End.Format "3:04 PM")
       "TimeZone" $next.ZoneString
-      "Permalink" (cond (ne $detailsPage nil) $detailsPage.RelPermalink "")
+      "Permalink" (cond (ne $detailsPage "") $detailsPage.RelPermalink "")
       "IsRecurring" true
       "Host" .host
       "LocationName" .location_name
       "LocationURL" .location_url
       "Image" .image
       "EventType" (.id | humanize | title)
+      "OfficialGcal" ""
       ) -}}
   {{- end -}}
 {{- end -}}


### PR DESCRIPTION
WHY: The Google Calendar API explicitly does not support programmatically generating "Invite via link" (slt token) URLs.
GOAL: Expose the `official_gcal` frontmatter parameter across the Hugo homepage and metadata components so manually retrieved RSVP links gracefully override the statically generated Google Calendar shortcut in the dropdown.