### PR TITLE
commit: Fix simulators category metadata

### DIFF
--- a/content/neuromorphic-computing/software/simulators/_index.md
+++ b/content/neuromorphic-computing/software/simulators/_index.md
@@ -1,0 +1,11 @@
+---
+title: Simulators for Neuromorphic Software
+description: Discover standalone simulation engines for neuromorphic modeling and biological neural networks.
+type: neuromorphic-software
+image: image.jpeg
+section_title: Simulators
+section_description: >-
+  Explore simulation engines optimized for running spiking neural networks. These tools provide the high-performance infrastructure needed to simulate biological dynamics, synaptic plasticity, and large-scale network structures.
+section: software-list
+category_id: simulator
+---

--- a/data/taxonomies/software-categories.json
+++ b/data/taxonomies/software-categories.json
@@ -14,5 +14,13 @@
     "page_intro": "Explore a comprehensive collection of essential data tools designed for the development of neuromorphic software, for managing and transforming neuromorphic (event-based) datasets.",
     "meta_description": "Discover data tools and libraries for reading, converting, and processing event-based and neuromorphic datasets.",
     "icon": "fas fa-database"
+  },
+  "simulator": {
+    "title": "Simulators",
+    "landing_path": "simulators",
+    "order": 3,
+    "page_intro": "Explore standalone simulation engines optimized for running spiking neural networks over extended periods. These frameworks focus on the dynamics, size, and structure of neural systems, often prioritizing execution speed and biological realism over gradient-based training.",
+    "meta_description": "Discover open-source SNN simulators for neuromorphic computing, including high-speed and biologically detailed simulation engines.",
+    "icon": "fas fa-server"
   }
 }

--- a/data/used_icons.yml
+++ b/data/used_icons.yml
@@ -26,6 +26,8 @@ fontawesome_svgs:
   - { style: solid, name: bullseye }
   - { style: solid, name: award }
   - { style: solid, name: download }
+  - { style: solid, name: server }
+  - { style: solid, name: database }
   - { style: brands, name: discord }
   - { style: brands, name: github }
   - { style: brands, name: twitter }

--- a/generate_context.py
+++ b/generate_context.py
@@ -6,7 +6,7 @@ import argparse
 import subprocess
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-OUTPUT_FILE = os.path.join(SCRIPT_DIR, "ai_context.md")
+OUTPUT_FILE = os.path.join(SCRIPT_DIR, "onm_website_hugo_code_bundle.md")
 
 EXCLUDE_DIRS = {
     ".git", "node_modules", "public", "resources", "tmp",


### PR DESCRIPTION
WHY:  Auryn needed to be integrated using the site's existing layout patterns, and FontAwesome icons needed to be officially registered for the sprite compiler.
GOAL: Establish the 'simulator' category correctly across taxonomy JSON and the section index, register missing SVG icons